### PR TITLE
set ARCHFLAGS appropriately for OSX (#169)

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -101,6 +101,10 @@ module RMagick
           $LOCAL_LIBS = ENV['LIBS'].to_s     + ' ' + `pkg-config --libs MagickCore`.chomp
         end
 
+        if RUBY_PLATFORM =~ /darwin/ # osx
+          set_archflags_for_osx
+        end
+
       elsif RUBY_PLATFORM =~ /mingw/  # mingw
 
         `convert -version` =~ /Version: ImageMagick (\d+\.\d+\.\d+)-\d+ /
@@ -199,6 +203,27 @@ SRC
           Logging.message msg
           message msg
        end
+    end
+
+    # issue #169
+    # set ARCHFLAGS appropriately for OSX
+    def set_archflags_for_osx
+      archflags = []
+      fullpath = `which convert` rescue nil
+      fileinfo = `file #{fullpath}` rescue nil
+
+      # default ARCHFLAGS
+      archs = $ARCH_FLAG.scan(/-arch\s+(\S+)/).flatten
+
+      archs.each do |arch|
+        if fileinfo.include?(arch)
+          archflags << "-arch #{arch}"
+        end
+      end
+
+      if archflags.length != 0
+        $ARCH_FLAG = archflags.join(" ")
+      end
     end
 
     def assert_can_compile!

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -222,7 +222,7 @@ SRC
       end
 
       if archflags.length != 0
-        $ARCH_FLAG = archflags.join(' ')
+        $ARCH_FLAG = archflags.join(" ")
       end
     end
 

--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -209,8 +209,8 @@ SRC
     # set ARCHFLAGS appropriately for OSX
     def set_archflags_for_osx
       archflags = []
-      fullpath = `which convert` rescue nil
-      fileinfo = `file #{fullpath}` rescue nil
+      fullpath = `which convert`
+      fileinfo = `file #{fullpath}`
 
       # default ARCHFLAGS
       archs = $ARCH_FLAG.scan(/-arch\s+(\S+)/).flatten
@@ -222,7 +222,7 @@ SRC
       end
 
       if archflags.length != 0
-        $ARCH_FLAG = archflags.join(" ")
+        $ARCH_FLAG = archflags.join(' ')
       end
     end
 


### PR DESCRIPTION
From  #169

To check ImageMagick architectures
```file``` command:
```
$ file `which convert`
/usr/local/bin/convert: Mach-O 64-bit executable x86_64
```