### PR TITLE
fix: in `require': cannot load such file -- rmagick/version (LoadError)

### DIFF
--- a/ext/RMagick/extconf.rb
+++ b/ext/RMagick/extconf.rb
@@ -1,3 +1,5 @@
+lib_dir = File.expand_path('../../lib', File.dirname(__FILE__))
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
 require 'mkmf'
 require 'date'
 


### PR DESCRIPTION
When clean installation from ```gemhome/master```, ```rmagick/version.rb``` is not found.
If some old rmagick (e.g. 2.13.4) is installed, the ```rmagick/version.rb``` is loaded, so no build error.

on ruby < 1.9.2, there are no ```require_relative```. #154
on ruby >= 1.9.2, ```require_relative``` exists. #142
