### PR TITLE
Fix for ImageMagick 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ env:
   # Latest 6.7 release
   - IMAGEMAGICK_VERSION=6.7.9-10
   # Latest 6.8 release
-  - IMAGEMAGICK_VERSION=6.8.9-6
+  - IMAGEMAGICK_VERSION=6.8.9-10
   # Try with HDRI support, we don't mind if this fails currently.
-  - IMAGEMAGICK_VERSION=6.8.9-6 CONFIGURE_OPTIONS=--enable-hdri
+  - IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
   # Latest 6.9 release
-  - IMAGEMAGICK_VERSION=6.9.0-5
+  - IMAGEMAGICK_VERSION=6.9.0-9
 
 before_install:
   - source before_install_$TRAVIS_OS_NAME.sh
@@ -36,27 +36,27 @@ matrix:
     - rvm: 1.8
       env: IMAGEMAGICK_VERSION=6.7.7-10
     - rvm: 1.8
-      env: IMAGEMAGICK_VERSION=6.8.9-6 CONFIGURE_OPTIONS=--enable-hdri
+      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
     - rvm: 1.8
-      env: IMAGEMAGICK_VERSION=6.8.9-6
+      env: IMAGEMAGICK_VERSION=6.8.9-10
     - rvm: 1.9
       env: IMAGEMAGICK_VERSION=6.7.9-10
     - rvm: 1.9
-      env: IMAGEMAGICK_VERSION=6.8.9-6 CONFIGURE_OPTIONS=--enable-hdri
+      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
     - rvm: 2.0
       env: IMAGEMAGICK_VERSION=6.7.7-10
     - rvm: 2.0
       env: IMAGEMAGICK_VERSION=6.7.9-10
     - rvm: 2.0
-      env: IMAGEMAGICK_VERSION=6.8.9-6
+      env: IMAGEMAGICK_VERSION=6.8.9-10
     - rvm: 2.0
-      env: IMAGEMAGICK_VERSION=6.8.9-6 CONFIGURE_OPTIONS=--enable-hdri
+      env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
   allow_failures:
     - rvm: 1.8
     - env: IMAGEMAGICK_VERSION=6.6.9-10 STYLE_CHECKS=true
     - env: IMAGEMAGICK_VERSION=6.7.7-10
     - env: IMAGEMAGICK_VERSION=6.7.9-10
-    - env: IMAGEMAGICK_VERSION=6.8.9-6 CONFIGURE_OPTIONS=--enable-hdri
+    - env: IMAGEMAGICK_VERSION=6.8.9-10 CONFIGURE_OPTIONS=--enable-hdri
 
 notifications:
   webhooks:


### PR DESCRIPTION
Looks like ImageMagick updated their patch level from `6.8.9-6` to
`6.8.9-10`