### PR TITLE
Silence warnings on Ruby 2.2

### DIFF
--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -176,21 +176,23 @@ Enum_spaceship(VALUE self, VALUE other)
 {
     MagickEnum *this, *that;
 
-    Data_Get_Struct(self, MagickEnum, this);
-    Data_Get_Struct(other, MagickEnum, that);
+    if(CLASS_OF(self) == CLASS_OF(other)) {
+        Data_Get_Struct(self, MagickEnum, this);
+        Data_Get_Struct(other, MagickEnum, that);
 
-    if (this->val > that->val)
-    {
-        return INT2FIX(1);
+        if (this->val > that->val)
+        {
+            return INT2FIX(1);
+        }
+        else if (this->val < that->val)
+        {
+            return INT2FIX(-1);
+        }
+
+        return INT2FIX(0);
     }
-    else if (this->val < that->val)
-    {
-        return INT2FIX(-1);
-    }
 
-    // Values are equal, check class.
-
-    return rb_funcall(CLASS_OF(self), rm_ID_spaceship, 1, CLASS_OF(other));
+    return Qnil;
 }
 
 


### PR DESCRIPTION
Hi there,

Ruby 2.2 raises warnings when an exception is raised in #<=> indicating that in the next version that exceptions won't be caught in #==. It also raises a warning that #<=> shouldn't raise exceptions, but instead return nil of the comparison is invalid.

In RMagick, comparing an `Magick::Enum` object (ie, any of the composite operator types etc.) with another Object of a different class triggers these warnings:

```
$ ruby -I./lib  -e 'require "rmagick"; puts (Magick::SubtractCompositeOp == :other).inspect'
-e:1: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
-e:1: warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.
false
```

This patch changes the `#<=>` method on `Magick::Enum` so it tests the classes first, so an exception isn't raised by the second `Data_Get_Struct` call when an object is passed in that isn't a `Magick::Enum`. After the fix:

```
$ ruby -I./lib  -e 'require "rmagick"; puts (Magick::SubtractCompositeOp <=> :pants).inspect; puts (Magick::SubtractCompositeOp == :pants).inspect'
nil
false
```


