### PR TITLE
Send in RUBY_VERSION.dup to Gem::Version

### DIFF
--- a/rmagick.gemspec
+++ b/rmagick.gemspec
@@ -31,11 +31,11 @@ Gem::Specification.new do |s|
   s.requirements << "ImageMagick #{Magick::MIN_IM_VERSION} or later"
   s.add_development_dependency 'rake-compiler'
 
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.2')
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('1.9.2')
     s.add_development_dependency 'rubocop', '~> 0.26.1'
   end
 
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
+  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.0')
     s.add_development_dependency 'test-unit', '~> 2'
   end
 end


### PR DESCRIPTION
It seems in versions of Ruby prior to 2.x, calling `Gem::Version.new` with a frozen string as an argument will result in a RuntimeError, since the library will attempt to mutate the string.
It seems to be a very similar problem [to this](https://groups.google.com/forum/#!topic/merb/EdwOwo64erE).

In versions of Ruby above 2.x the Gem::Version library does a .dup on the object that comes in right away, so there it shouldn't be a problem.

Important to note is that reproducing after noticing it was problematic. With no Ruby versions at first in rbenv, I bumped into the issue (tried Ruby `1.9.3` first). When I resolved it by adding the changes proposed in the PR, the `bundle install` went through. On subsequent attempts to reproduce the issue (by removing the `.dup` from the two lines) everything worked as if it wasn't a problem in the first place.

I'm not sure why this is the case, but it's definitely something that might stump a newcomer unnecessarily.

The changes shouldn't affect newer Rubies in any noticeable way. If you think this is an unnecessary change (since it seems hard to reproduce), feel free to close the PR.