### PR TITLE
replaced `volatile VALUE X` with `RB_GC_GUARD(X)`

### DIFF
--- a/ext/RMagick/rmagick.c
+++ b/ext/RMagick/rmagick.c
@@ -34,7 +34,7 @@ Magick_colors(VALUE class)
 {
     const ColorInfo **color_info_list;
     size_t number_colors, x;
-    volatile VALUE ary;
+    VALUE ary;
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
@@ -62,6 +62,7 @@ Magick_colors(VALUE class)
         }
 
         magick_free((void *)color_info_list);
+        RB_GC_GUARD(ary);
         return ary;
     }
 }
@@ -83,7 +84,7 @@ Magick_fonts(VALUE class)
 {
     const TypeInfo **type_info;
     size_t number_types, x;
-    volatile VALUE ary;
+    VALUE ary;
     ExceptionInfo *exception;
 
     exception = AcquireExceptionInfo();
@@ -108,6 +109,7 @@ Magick_fonts(VALUE class)
             (void) rb_ary_push(ary, Import_TypeInfo((const TypeInfo *)type_info[x]));
         }
         magick_free((void *)type_info);
+        RB_GC_GUARD(ary);
         return ary;
     }
 
@@ -167,7 +169,7 @@ Magick_init_formats(VALUE class)
 {
     const MagickInfo **magick_info;
     size_t number_formats, x;
-    volatile VALUE formats;
+    VALUE formats;
     ExceptionInfo *exception;
 
     class = class;      // defeat "never referenced" message from icc
@@ -186,6 +188,7 @@ Magick_init_formats(VALUE class)
                             , rb_str_new2(magick_info[x]->name)
                             , MagickInfo_to_format((const MagickInfo *)magick_info[x]));
     }
+    RB_GC_GUARD(formats);
     return formats;
 }
 
@@ -206,7 +209,7 @@ Magick_init_formats(VALUE class)
 VALUE
 Magick_limit_resource(int argc, VALUE *argv, VALUE class)
 {
-    volatile VALUE resource, limit;
+    VALUE resource, limit;
     ResourceType res = UndefinedResource;
     char *str;
     ID id;
@@ -280,12 +283,16 @@ Magick_limit_resource(int argc, VALUE *argv, VALUE class)
             break;
     }
 
+    RB_GC_GUARD(resource);
+
     cur_limit = GetMagickResourceLimit(res);
 
     if (argc > 1)
     {
         (void) SetMagickResourceLimit(res, (MagickSizeType)NUM2ULONG(limit));
     }
+
+    RB_GC_GUARD(limit);
 
     return ULONG2NUM(cur_limit);
 }

--- a/ext/RMagick/rmagick.h
+++ b/ext/RMagick/rmagick.h
@@ -139,6 +139,10 @@
 #define RARRAY_PTR(a) RARRAY((a))->ptr /**< Ruby array pointer */
 #endif
 
+// Backport this macro to 1.8.6
+#if !defined(RB_GC_GUARD)
+#define RB_GC_GUARD(x) (x)
+#endif
 
 //! Convert a C string to a Ruby symbol. Used in marshal_dump/marshal_load methods
 #define CSTR2SYM(s) ID2SYM(rb_intern(s))

--- a/ext/RMagick/rmenum.c
+++ b/ext/RMagick/rmenum.c
@@ -78,10 +78,13 @@ VALUE
 Enum_alloc(VALUE class)
 {
    MagickEnum *magick_enum;
-   volatile VALUE enumr;
+   VALUE enumr;
 
    enumr = Data_Make_Struct(class, MagickEnum, NULL, NULL, magick_enum);
    rb_obj_freeze(enumr);
+
+   RB_GC_GUARD(enumr);
+
    return enumr;
 }
 
@@ -230,7 +233,7 @@ VALUE
 Enum_type_initialize(VALUE self, VALUE sym, VALUE val)
 {
     VALUE super_argv[2];
-    volatile VALUE enumerators;
+    VALUE enumerators;
 
     super_argv[0] = sym;
     super_argv[1] = val;
@@ -243,6 +246,8 @@ Enum_type_initialize(VALUE self, VALUE sym, VALUE val)
 
     enumerators = rb_cv_get(CLASS_OF(self), ENUMERATORS_CLASS_VAR);
     (void) rb_ary_push(enumerators, self);
+
+    RB_GC_GUARD(enumerators);
 
     return self;
 }
@@ -286,8 +291,8 @@ Enum_type_inspect(VALUE self)
 static VALUE
 Enum_type_values(VALUE class)
 {
-    volatile VALUE enumerators, copy;
-    volatile VALUE rv;
+    VALUE enumerators, copy;
+    VALUE rv;
     int x;
 
     enumerators = rb_cv_get(class, ENUMERATORS_CLASS_VAR);
@@ -310,6 +315,10 @@ Enum_type_values(VALUE class)
         rb_obj_freeze(copy);
         rv = copy;
     }
+
+    RB_GC_GUARD(enumerators);
+    RB_GC_GUARD(copy);
+    RB_GC_GUARD(rv);
 
     return rv;
 }

--- a/ext/RMagick/rmfill.c
+++ b/ext/RMagick/rmfill.c
@@ -675,7 +675,7 @@ TextureFill_initialize(VALUE self, VALUE texture_arg)
 {
     rm_TextureFill *fill;
     Image *texture;
-    volatile VALUE texture_image;
+    VALUE texture_image;
 
     Data_Get_Struct(self, rm_TextureFill, fill);
 
@@ -686,6 +686,9 @@ TextureFill_initialize(VALUE self, VALUE texture_arg)
     (void) ReferenceImage(texture);
 
     fill->texture = texture;
+
+    RB_GC_GUARD(texture_image);
+
     return self;
 }
 

--- a/ext/RMagick/rminfo.c
+++ b/ext/RMagick/rminfo.c
@@ -317,7 +317,7 @@ VALUE
 Info_aset(int argc, VALUE *argv, VALUE self)
 {
     Info *info;
-    volatile VALUE value;
+    VALUE value;
     char *format_p, *key_p, *value_p = NULL;
     long format_l, key_l;
     char ckey[MaxTextExtent];
@@ -373,6 +373,7 @@ Info_aset(int argc, VALUE *argv, VALUE self)
         }
     }
 
+    RB_GC_GUARD(value);
 
     return self;
 }
@@ -745,7 +746,7 @@ Info_define(int argc, VALUE *argv, VALUE self)
     long format_l, key_l;
     char ckey[100];
     unsigned int okay;
-    volatile VALUE fmt_arg;
+    VALUE fmt_arg;
 
     Data_Get_Struct(self, Info, info);
 
@@ -776,6 +777,8 @@ Info_define(int argc, VALUE *argv, VALUE self)
         rb_warn("%.20s=\"%.78s\" not defined - SetImageOption failed.", ckey, value);
         return Qnil;
     }
+
+    RB_GC_GUARD(fmt_arg);
 
     return self;
 }
@@ -903,7 +906,7 @@ VALUE
 Info_density_eq(VALUE self, VALUE density_arg)
 {
     Info *info;
-    volatile VALUE density;
+    VALUE density;
     char *dens;
 
     Data_Get_Struct(self, Info, info);
@@ -923,6 +926,8 @@ Info_density_eq(VALUE self, VALUE density_arg)
     }
 
     magick_clone_string(&info->density, dens);
+
+    RB_GC_GUARD(density);
 
     return self;
 }
@@ -1189,7 +1194,7 @@ Info_extract_eq(VALUE self, VALUE extract_arg)
 {
     Info *info;
     char *extr;
-    volatile VALUE extract;
+    VALUE extract;
 
     Data_Get_Struct(self, Info, info);
 
@@ -1208,6 +1213,8 @@ Info_extract_eq(VALUE self, VALUE extract_arg)
     }
 
     magick_clone_string(&info->extract, extr);
+
+    RB_GC_GUARD(extract);
 
     return self;
 }
@@ -1816,7 +1823,7 @@ VALUE
 Info_origin_eq(VALUE self, VALUE origin_arg)
 {
     Info *info;
-    volatile VALUE origin_str;
+    VALUE origin_str;
     char *origin;
 
     Data_Get_Struct(self, Info, info);
@@ -1836,6 +1843,9 @@ Info_origin_eq(VALUE self, VALUE origin_arg)
     }
 
     (void) SetImageOption(info, "origin", origin);
+
+    RB_GC_GUARD(origin_str);
+
     return self;
 }
 
@@ -1874,7 +1884,7 @@ VALUE
 Info_page_eq(VALUE self, VALUE page_arg)
 {
     Info *info;
-    volatile VALUE geom_str;
+    VALUE geom_str;
     char *geometry;
 
     Data_Get_Struct(self, Info, info);
@@ -1893,6 +1903,8 @@ Info_page_eq(VALUE self, VALUE page_arg)
         return self;
     }
     magick_clone_string(&info->page, geometry);
+
+    RB_GC_GUARD(geom_str);
 
     return self;
 }
@@ -2081,7 +2093,7 @@ VALUE
 Info_size_eq(VALUE self, VALUE size_arg)
 {
     Info *info;
-    volatile VALUE size;
+    VALUE size;
     char *sz;
 
     Data_Get_Struct(self, Info, info);
@@ -2101,6 +2113,8 @@ Info_size_eq(VALUE self, VALUE size_arg)
     }
 
     magick_clone_string(&info->size, sz);
+
+    RB_GC_GUARD(size);
 
     return self;
 }
@@ -2235,7 +2249,7 @@ VALUE
 Info_tile_offset_eq(VALUE self, VALUE offset)
 {
     Info *info;
-    volatile VALUE offset_str;
+    VALUE offset_str;
     char *tile_offset;
 
     offset_str = rm_to_s(offset);
@@ -2249,6 +2263,9 @@ Info_tile_offset_eq(VALUE self, VALUE offset)
 
     (void) DeleteImageOption(info, "tile-offset");
     (void) SetImageOption(info, "tile-offset", tile_offset);
+
+    RB_GC_GUARD(offset_str);
+
     return self;
 }
 
@@ -2513,7 +2530,7 @@ VALUE
 Info_alloc(VALUE class)
 {
     Info *info;
-    volatile VALUE info_obj;
+    VALUE info_obj;
 
     info = CloneImageInfo(NULL);
     if (!info)
@@ -2521,6 +2538,9 @@ Info_alloc(VALUE class)
         rb_raise(rb_eNoMemError, "not enough memory to initialize Info object");
     }
     info_obj = Data_Wrap_Struct(class, NULL, destroy_Info, info);
+
+    RB_GC_GUARD(info_obj);
+
     return info_obj;
 }
 
@@ -2538,9 +2558,12 @@ Info_alloc(VALUE class)
 VALUE
 rm_info_new(void)
 {
-    volatile VALUE info_obj;
+    VALUE info_obj;
 
     info_obj = Info_alloc(Class_Info);
+
+    RB_GC_GUARD(info_obj);
+
     return Info_initialize(info_obj);
 }
 

--- a/ext/RMagick/rmmain.c
+++ b/ext/RMagick/rmmain.c
@@ -131,7 +131,7 @@ static void set_managed_memory(void)
 void
 Init_RMagick2(void)
 {
-    volatile VALUE observable;
+    VALUE observable;
 
     MagickCoreGenesis("RMagick", MagickFalse);
 
@@ -1620,6 +1620,7 @@ Init_RMagick2(void)
     SetErrorHandler(rm_error_handler);
     SetWarningHandler(rm_warning_handler);
 
+    RB_GC_GUARD(observable);
 }
 
 
@@ -1681,7 +1682,7 @@ static void
 version_constants(void)
 {
     const char *mgk_version;
-    volatile VALUE str;
+    VALUE str;
     char long_version[1000];
 
     mgk_version = GetMagickVersion(NULL);
@@ -1706,6 +1707,7 @@ version_constants(void)
     rb_obj_freeze(str);
     rb_define_const(Module_Magick, "Long_version", str);
 
+    RB_GC_GUARD(str);
 }
 
 
@@ -1717,7 +1719,7 @@ version_constants(void)
 static void
 features_constant(void)
 {
-    volatile VALUE features;
+    VALUE features;
 
 #if defined(HAVE_GETMAGICKFEATURES)
     // 6.5.7 - latest (7.0.0)
@@ -1734,4 +1736,6 @@ features_constant(void)
 
     rb_obj_freeze(features);
     rb_define_const(Module_Magick, "Magick_features", features);
+
+    RB_GC_GUARD(features);
 }

--- a/ext/RMagick/rmmontage.c
+++ b/ext/RMagick/rmmontage.c
@@ -63,7 +63,7 @@ Montage_alloc(VALUE class)
     MontageInfo *montage_info;
     Montage *montage;
     Info *image_info;
-    volatile VALUE montage_obj;
+    VALUE montage_obj;
 
     // DO NOT call rm_info_new - we don't want to support an Info parm block.
     image_info = CloneImageInfo(NULL);
@@ -84,6 +84,8 @@ Montage_alloc(VALUE class)
     montage->info = montage_info;
     montage->compose = OverCompositeOp;
     montage_obj = Data_Wrap_Struct(class, NULL, destroy_Montage, montage);
+
+    RB_GC_GUARD(montage_obj);
 
     return montage_obj;
 }
@@ -256,11 +258,13 @@ VALUE
 Montage_frame_eq(VALUE self, VALUE frame_arg)
 {
     Montage *montage;
-    volatile VALUE frame;
+    VALUE frame;
 
     Data_Get_Struct(self, Montage, montage);
     frame = rm_to_s(frame_arg);
     magick_clone_string(&montage->info->frame, StringValuePtr(frame));
+
+    RB_GC_GUARD(frame);
 
     return self;
 }
@@ -280,11 +284,13 @@ VALUE
 Montage_geometry_eq(VALUE self, VALUE geometry_arg)
 {
     Montage *montage;
-    volatile VALUE geometry;
+    VALUE geometry;
 
     Data_Get_Struct(self, Montage, montage);
     geometry = rm_to_s(geometry_arg);
     magick_clone_string(&montage->info->geometry, StringValuePtr(geometry));
+
+    RB_GC_GUARD(geometry);
 
     return self;
 }
@@ -465,11 +471,13 @@ VALUE
 Montage_tile_eq(VALUE self, VALUE tile_arg)
 {
     Montage *montage;
-    volatile VALUE tile;
+    VALUE tile;
 
     Data_Get_Struct(self, Montage, montage);
     tile = rm_to_s(tile_arg);
     magick_clone_string(&montage->info->tile, StringValuePtr(tile));
+
+    RB_GC_GUARD(tile);
 
     return self;
 }

--- a/ext/RMagick/rmpixel.c
+++ b/ext/RMagick/rmpixel.c
@@ -294,13 +294,15 @@ Pixel_case_eq(VALUE self, VALUE other)
 VALUE
 Pixel_clone(VALUE self)
 {
-    volatile VALUE clone;
+    VALUE clone;
 
     clone = Pixel_dup(self);
     if (OBJ_FROZEN(self))
     {
         OBJ_FREEZE(clone);
     }
+
+    RB_GC_GUARD(clone);
 
     return clone;
 }
@@ -321,7 +323,7 @@ VALUE
 Pixel_dup(VALUE self)
 {
     Pixel *pixel;
-    volatile VALUE dup;
+    VALUE dup;
 
     pixel = ALLOC(Pixel);
     memset(pixel, '\0', sizeof(Pixel));
@@ -330,6 +332,9 @@ Pixel_dup(VALUE self)
     {
         (void) rb_obj_taint(dup);
     }
+
+    RB_GC_GUARD(dup);
+
     return rb_funcall(dup, rm_ID_initialize_copy, 1, self);
 }
 
@@ -794,7 +799,7 @@ VALUE
 Pixel_marshal_dump(VALUE self)
 {
     Pixel *pixel;
-    volatile VALUE dpixel;
+    VALUE dpixel;
 
     Data_Get_Struct(self, Pixel, pixel);
     dpixel = rb_hash_new();
@@ -802,6 +807,9 @@ Pixel_marshal_dump(VALUE self)
     rb_hash_aset(dpixel, CSTR2SYM("green"), QUANTUM2NUM(pixel->green));
     rb_hash_aset(dpixel, CSTR2SYM("blue"), QUANTUM2NUM(pixel->blue));
     rb_hash_aset(dpixel, CSTR2SYM("opacity"), QUANTUM2NUM(pixel->opacity));
+
+    RB_GC_GUARD(dpixel);
+
     return dpixel;
 }
 
@@ -892,7 +900,7 @@ Pixel_to_hsla(VALUE self)
 {
     double hue, sat, lum, alpha;
     Pixel *pixel;
-    volatile VALUE hsla;
+    VALUE hsla;
 
     Data_Get_Struct(self, Pixel, pixel);
 
@@ -915,6 +923,9 @@ Pixel_to_hsla(VALUE self)
     }
 
     hsla = rb_ary_new3(4, rb_float_new(hue), rb_float_new(sat), rb_float_new(lum), rb_float_new(alpha));
+
+    RB_GC_GUARD(hsla);
+
     return hsla;
 }
 
@@ -933,7 +944,7 @@ Pixel_to_HSL(VALUE self)
 {
     Pixel *pixel;
     double hue, saturation, luminosity;
-    volatile VALUE hsl;
+    VALUE hsl;
 
     Data_Get_Struct(self, Pixel, pixel);
 
@@ -942,6 +953,8 @@ Pixel_to_HSL(VALUE self)
 
     hsl = rb_ary_new3(3, rb_float_new(hue), rb_float_new(saturation),
                       rb_float_new(luminosity));
+
+    RB_GC_GUARD(hsl);
 
     return hsl;
 }

--- a/ext/RMagick/rmstruct.c
+++ b/ext/RMagick/rmstruct.c
@@ -65,7 +65,7 @@ Import_AffineMatrix(AffineMatrix *affine)
 void
 Export_AffineMatrix(AffineMatrix *am, VALUE st)
 {
-    volatile VALUE values, v;
+    VALUE values, v;
 
     if (CLASS_OF(st) != Class_AffineMatrix)
     {
@@ -85,6 +85,9 @@ Export_AffineMatrix(AffineMatrix *am, VALUE st)
     am->tx = v == Qnil ? 0.0 : NUM2DBL(v);
     v = rb_ary_entry(values, 5);
     am->ty = v == Qnil ? 0.0 : NUM2DBL(v);
+
+    RB_GC_GUARD(values);
+    RB_GC_GUARD(v);
 }
 
 
@@ -99,15 +102,20 @@ Export_AffineMatrix(AffineMatrix *am, VALUE st)
 VALUE
 ChromaticityInfo_new(ChromaticityInfo *ci)
 {
-    volatile VALUE red_primary;
-    volatile VALUE green_primary;
-    volatile VALUE blue_primary;
-    volatile VALUE white_point;
+    VALUE red_primary;
+    VALUE green_primary;
+    VALUE blue_primary;
+    VALUE white_point;
 
     red_primary   = Import_PrimaryInfo(&ci->red_primary);
     green_primary = Import_PrimaryInfo(&ci->green_primary);
     blue_primary  = Import_PrimaryInfo(&ci->blue_primary);
     white_point   = Import_PrimaryInfo(&ci->white_point);
+
+    RB_GC_GUARD(red_primary);
+    RB_GC_GUARD(green_primary);
+    RB_GC_GUARD(blue_primary);
+    RB_GC_GUARD(white_point);
 
     return rb_funcall(Class_Chromaticity, rm_ID_new, 4
                     , red_primary, green_primary, blue_primary, white_point);
@@ -126,9 +134,9 @@ ChromaticityInfo_new(ChromaticityInfo *ci)
 void
 Export_ChromaticityInfo(ChromaticityInfo *ci, VALUE chrom)
 {
-    volatile VALUE chrom_members;
-    volatile VALUE red_primary, green_primary, blue_primary, white_point;
-    volatile VALUE entry_members, x, y;
+    VALUE chrom_members;
+    VALUE red_primary, green_primary, blue_primary, white_point;
+    VALUE entry_members, x, y;
     ID values_id;
 
     if (CLASS_OF(chrom) != Class_Chromaticity)
@@ -176,6 +184,15 @@ Export_ChromaticityInfo(ChromaticityInfo *ci, VALUE chrom)
     y = rb_ary_entry(entry_members, 1);         // white_point.y
     ci->white_point.y = y == Qnil ? 0.0 : NUM2DBL(y);
     ci->white_point.z = 0.0;
+
+    RB_GC_GUARD(chrom_members);
+    RB_GC_GUARD(red_primary);
+    RB_GC_GUARD(green_primary);
+    RB_GC_GUARD(blue_primary);
+    RB_GC_GUARD(white_point);
+    RB_GC_GUARD(entry_members);
+    RB_GC_GUARD(x);
+    RB_GC_GUARD(y);
 }
 
 
@@ -219,15 +236,19 @@ VALUE
 Import_ColorInfo(const ColorInfo *ci)
 {
     ComplianceType compliance_type;
-    volatile VALUE name;
-    volatile VALUE compliance;
-    volatile VALUE color;
+    VALUE name;
+    VALUE compliance;
+    VALUE color;
 
     name       = rb_str_new2(ci->name);
 
     compliance_type = ci->compliance;
     compliance = ComplianceType_new(compliance_type);
     color      = Pixel_from_MagickPixelPacket(&(ci->color));
+
+    RB_GC_GUARD(name);
+    RB_GC_GUARD(compliance);
+    RB_GC_GUARD(color);
 
     return rb_funcall(Class_Color, rm_ID_new, 3
                     , name, compliance, color);
@@ -246,7 +267,7 @@ void
 Export_ColorInfo(ColorInfo *ci, VALUE st)
 {
     Pixel *pixel;
-    volatile VALUE members, m;
+    VALUE members, m;
 
     if (CLASS_OF(st) != Class_Color)
     {
@@ -281,6 +302,9 @@ Export_ColorInfo(ColorInfo *ci, VALUE st)
         ci->color.opacity = (MagickRealType) OpaqueOpacity;
         ci->color.index = (MagickRealType) 0;
     }
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
 }
 
 
@@ -441,9 +465,9 @@ ComplianceType_new(ComplianceType compliance)
 VALUE
 Import_TypeInfo(const TypeInfo *ti)
 {
-    volatile VALUE name, description, family;
-    volatile VALUE style, stretch, weight;
-    volatile VALUE encoding, foundry, format;
+    VALUE name, description, family;
+    VALUE style, stretch, weight;
+    VALUE encoding, foundry, format;
 
     name        = rb_str_new2(ti->name);
     family      = rb_str_new2(ti->family);
@@ -454,6 +478,16 @@ Import_TypeInfo(const TypeInfo *ti)
     encoding    = ti->encoding    ? rb_str_new2(ti->encoding) : Qnil;
     foundry     = ti->foundry     ? rb_str_new2(ti->foundry)  : Qnil;
     format      = ti->format      ? rb_str_new2(ti->format)   : Qnil;
+
+    RB_GC_GUARD(name);
+    RB_GC_GUARD(description);
+    RB_GC_GUARD(family);
+    RB_GC_GUARD(style);
+    RB_GC_GUARD(stretch);
+    RB_GC_GUARD(weight);
+    RB_GC_GUARD(encoding);
+    RB_GC_GUARD(foundry);
+    RB_GC_GUARD(format);
 
     return rb_funcall(Class_Font, rm_ID_new, 9
                     , name, description, family, style
@@ -472,7 +506,7 @@ Import_TypeInfo(const TypeInfo *ti)
 void
 Export_TypeInfo(TypeInfo *ti, VALUE st)
 {
-    volatile VALUE members, m;
+    VALUE members, m;
 
     if (CLASS_OF(st) != Class_Font)
     {
@@ -511,6 +545,9 @@ Export_TypeInfo(TypeInfo *ti, VALUE st)
     m = rb_ary_entry(members, 8);
     if (m != Qnil)
         (void) CloneString((char **)&(ti->format), StringValuePtr(m));
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
 }
 
 
@@ -616,7 +653,7 @@ Import_PointInfo(PointInfo *p)
 void
 Export_PointInfo(PointInfo *pi, VALUE sp)
 {
-    volatile VALUE members, m;
+    VALUE members, m;
 
     if (CLASS_OF(sp) != Class_Point)
     {
@@ -628,6 +665,9 @@ Export_PointInfo(PointInfo *pi, VALUE sp)
     pi->x = m == Qnil ? 0.0 : NUM2DBL(m);
     m = rb_ary_entry(members, 1);
     pi->y = m == Qnil ? 0.0 : NUM2DBL(m);
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
 }
 
 
@@ -658,7 +698,7 @@ Import_PrimaryInfo(PrimaryInfo *p)
 void
 Export_PrimaryInfo(PrimaryInfo *pi, VALUE sp)
 {
-    volatile VALUE members, m;
+    VALUE members, m;
 
     if (CLASS_OF(sp) != Class_Primary)
     {
@@ -672,6 +712,9 @@ Export_PrimaryInfo(PrimaryInfo *pi, VALUE sp)
     pi->y = m == Qnil ? 0.0 : NUM2DBL(m);
     m = rb_ary_entry(members, 2);
     pi->z = m == Qnil ? 0.0 : NUM2DBL(m);
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
 }
 
 
@@ -707,14 +750,20 @@ PrimaryInfo_to_s(VALUE self)
 VALUE
 Import_RectangleInfo(RectangleInfo *rect)
 {
-    volatile VALUE width;
-    volatile VALUE height;
-    volatile VALUE x, y;
+    VALUE width;
+    VALUE height;
+    VALUE x, y;
 
     width  = UINT2NUM(rect->width);
     height = UINT2NUM(rect->height);
     x      = INT2NUM(rect->x);
     y      = INT2NUM(rect->y);
+
+    RB_GC_GUARD(width);
+    RB_GC_GUARD(height);
+    RB_GC_GUARD(x);
+    RB_GC_GUARD(y);
+
     return rb_funcall(Class_Rectangle, rm_ID_new, 4
                     , width, height, x, y);
 }
@@ -731,7 +780,7 @@ Import_RectangleInfo(RectangleInfo *rect)
 void
 Export_RectangleInfo(RectangleInfo *rect, VALUE sr)
 {
-    volatile VALUE members, m;
+    VALUE members, m;
 
     if (CLASS_OF(sr) != Class_Rectangle)
     {
@@ -747,6 +796,9 @@ Export_RectangleInfo(RectangleInfo *rect, VALUE sr)
     rect->x      = m == Qnil ? 0 : NUM2LONG (m);
     m = rb_ary_entry(members, 3);
     rect->y      = m == Qnil ? 0 : NUM2LONG (m);
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
 }
 
 
@@ -783,12 +835,18 @@ RectangleInfo_to_s(VALUE self)
 VALUE
 Import_SegmentInfo(SegmentInfo *segment)
 {
-    volatile VALUE x1, y1, x2, y2;
+    VALUE x1, y1, x2, y2;
 
     x1 = rb_float_new(segment->x1);
     y1 = rb_float_new(segment->y1);
     x2 = rb_float_new(segment->x2);
     y2 = rb_float_new(segment->y2);
+
+    RB_GC_GUARD(x1);
+    RB_GC_GUARD(y1);
+    RB_GC_GUARD(x2);
+    RB_GC_GUARD(y2);
+    
     return rb_funcall(Class_Segment, rm_ID_new, 4, x1, y1, x2, y2);
 }
 
@@ -804,7 +862,7 @@ Import_SegmentInfo(SegmentInfo *segment)
 void
 Export_SegmentInfo(SegmentInfo *segment, VALUE s)
 {
-    volatile VALUE members, m;
+    VALUE members, m;
 
     if (CLASS_OF(s) != Class_Segment)
     {
@@ -821,6 +879,9 @@ Export_SegmentInfo(SegmentInfo *segment, VALUE s)
     segment->x2 = m == Qnil ? 0.0 : NUM2DBL(m);
     m = rb_ary_entry(members, 3);
     segment->y2 = m == Qnil ? 0.0 : NUM2DBL(m);
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
 }
 
 
@@ -943,10 +1004,10 @@ StyleType_new(StyleType style)
 VALUE
 Import_TypeMetric(TypeMetric *tm)
 {
-    volatile VALUE pixels_per_em;
-    volatile VALUE ascent, descent;
-    volatile VALUE width, height, max_advance;
-    volatile VALUE bounds, underline_position, underline_thickness;
+    VALUE pixels_per_em;
+    VALUE ascent, descent;
+    VALUE width, height, max_advance;
+    VALUE bounds, underline_position, underline_thickness;
 
     pixels_per_em       = Import_PointInfo(&tm->pixels_per_em);
     ascent              = rb_float_new(tm->ascent);
@@ -957,6 +1018,16 @@ Import_TypeMetric(TypeMetric *tm)
     bounds              = Import_SegmentInfo(&tm->bounds);
     underline_position  = rb_float_new(tm->underline_position);
     underline_thickness = rb_float_new(tm->underline_position);
+
+    RB_GC_GUARD(pixels_per_em);
+    RB_GC_GUARD(ascent);
+    RB_GC_GUARD(descent);
+    RB_GC_GUARD(width);
+    RB_GC_GUARD(height);
+    RB_GC_GUARD(max_advance);
+    RB_GC_GUARD(bounds);
+    RB_GC_GUARD(underline_position);
+    RB_GC_GUARD(underline_thickness);
 
     return rb_funcall(Class_TypeMetric, rm_ID_new, 9
                     , pixels_per_em, ascent, descent, width
@@ -976,8 +1047,8 @@ Import_TypeMetric(TypeMetric *tm)
 void
 Export_TypeMetric(TypeMetric *tm, VALUE st)
 {
-    volatile VALUE members, m;
-    volatile VALUE pixels_per_em;
+    VALUE members, m;
+    VALUE pixels_per_em;
 
     if (CLASS_OF(st) != Class_TypeMetric)
     {
@@ -1007,6 +1078,10 @@ Export_TypeMetric(TypeMetric *tm, VALUE st)
     tm->underline_position  = m == Qnil ? 0.0 : NUM2DBL(m);
     m = rb_ary_entry(members, 8);
     tm->underline_thickness = m == Qnil ? 0.0 : NUM2DBL(m);
+
+    RB_GC_GUARD(members);
+    RB_GC_GUARD(m);
+    RB_GC_GUARD(pixels_per_em);
 }
 
 
@@ -1022,7 +1097,7 @@ Export_TypeMetric(TypeMetric *tm, VALUE st)
 VALUE
 TypeMetric_to_s(VALUE self)
 {
-    volatile VALUE str;
+    VALUE str;
     TypeMetric tm;
     char temp[200];
     int len;
@@ -1041,6 +1116,8 @@ TypeMetric_to_s(VALUE self)
     rb_str_cat(str, temp, len);
     len = sprintf(temp, "underline_position=%g underline_thickness=%g", tm.underline_position, tm.underline_thickness);
     rb_str_cat(str, temp, len);
+
+    RB_GC_GUARD(str);
 
     return str;
 }


### PR DESCRIPTION
From #176

I merely replaced `volatile VALUE X` with `RB_GC_GUARD(X)`.
(Perhaps some `RB_GC_GUARD` are unnecessary, but status quo for now)

> RB_GC_GUARD is only effective on the VALUE data type, not converted C data types.

> 3) “volatile” implementations may be buggy/inconsistent in some
compilers and architectures. RB_GC_GUARD is customizable for broken
systems/compilers without those without negatively affecting other
systems.

[Appendix E. RB_GC_GUARD to protect from premature GC](https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc#appendix-e-rb_gc_guard-to-protect-from-premature-gc)