### PR TITLE
fixed segfault in `Magick#trace_proc=` for ruby 2.2.X

### DIFF
--- a/lib/rmagick_internal.rb
+++ b/lib/rmagick_internal.rb
@@ -30,12 +30,15 @@ module Magick
 
     # remove reference to the proc at exit
     def trace_proc=(p)
-      if @trace_proc.nil? && !p.nil? && !@exit_block_set_up
-        at_exit { @trace_proc = nil }
-        @exit_block_set_up = true
-      end
+      m = Mutex.new
+      m.synchronize do
+        if @trace_proc.nil? && !p.nil? && !@exit_block_set_up
+          at_exit { @trace_proc = nil }
+          @exit_block_set_up = true
+        end
 
-      @trace_proc = p
+        @trace_proc = p
+      end
     end
   end
 


### PR DESCRIPTION
Segfault Log:
https://travis-ci.org/gemhome/rmagick/jobs/60001052

segfault reproduction script (on Ruby 2.2.X):
```rb
require 'rmagick'
require 'test/unit'

class SegfaultTest < Test::Unit::TestCase
  def test_segfault
    def create_img
      local_img = Magick::Image.new(20, 20)
    end
    
    create_img
    GC.stress = true

    proc1 = proc do |which, id, addr, method|
      assert(which == :c)
    end

    Magick.trace_proc = proc1
    img = Magick::Image.new(777, 777)
  end
end
```

If `local_img` is garbage collected in `Magick#trace_proc=`,
`Image#destroy!` and `Magick#trace_proc`(i.e. `proc1`) will be called **in the middle of `Magick#trace_proc=`**.
At this time, `Magick#trace_proc` might be not completely prepared yet,
so segmentation fault will be raised.

[Magick#trace_proc](http://www.imagemagick.org/RMagick/doc/magick.html#trace_proc):

> If the Magick module attribute trace_proc is set to a Proc object, RMagick calls the proc whenever an image is created or destroyed.


