### PR TITLE
Fix Ruby 1.8 segfault

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -93,6 +93,13 @@ LD_LIBRARY_PATH variable like this:
 On Linux, see @ld(1)@ and @ld.so(8)@ for more information. On other operating
 systems, see the documentation for the dynamic loading facility.
 
+h4. Segmentation fault
+
+Default stack size of your operating system might be too small. Try removing the limit with this command:
+
+<pre>
+        ulimit -s unlimited
+</pre>
 
 h2(#upgrade). Upgrading
 

--- a/before_install_linux.sh
+++ b/before_install_linux.sh
@@ -19,3 +19,8 @@ esac
 sudo make install
 cd ..
 sudo ldconfig
+
+if [[ $TRAVIS_RUBY_VERSION =~ ^1.8 ]]; then
+    echo "Set the stack size to unlimited to avoid segfault for Ruby 1.8"
+    ulimit -s unlimited
+fi


### PR DESCRIPTION
[Job #404.20 - gemhome/rmagick - Travis CI](https://travis-ci.org/gemhome/rmagick/jobs/62917281)
repro script foo.rb(from test/Info.rb):
```rb
require 'rubygems'
require 'rmagick'

monitor = proc do |mth, q, s|
  puts s
  true
end

img = Magick::Image.new(2000, 2000) { self.monitor = monitor }
img.resize!(20, 20)
img.monitor = nil
```

```sh
$ ruby -v
ruby 1.8.7 (2013-12-22 patchlevel 375) [x86_64-linux]
$ ruby foo.rb
40
40
40
40
foo.rb:6: stack level too deep (SystemStackError)
	from foo.rb:10:in `call'
	from foo.rb:10:in `resize!'
	from foo.rb:10
foo.rb:6: [BUG] Segmentation fault
ruby 1.8.7 (2013-12-22 patchlevel 375) [x86_64-linux]

Aborted (core dumped)
```

Ruby 1.8 uses C stack. (Ruby 1.9 and later use RubyVM stack)
The cause for segfault might be that C stack size limit is too small.
Some ImageMagick functions run in parallel with OpenMP that often causes stack size problems.