### PR TITLE
Fixed #202; Avoid a loop in linked list

### DIFF
--- a/ext/RMagick/rmilist.c
+++ b/ext/RMagick/rmilist.c
@@ -816,6 +816,11 @@ images_from_imagelist(VALUE imagelist)
 
         t = rb_ary_entry(images, x);
         image = rm_check_destroyed(t);
+        // avoid a loop in this linked imagelist, issue #202
+        if (head == image || GetPreviousImageInList(image) != NULL)
+        {
+            image = rm_clone_image(image);
+        }
         AppendImageToList(&head, image);
     }
 

--- a/spec/rmagick/ImageList1_spec.rb
+++ b/spec/rmagick/ImageList1_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Magick::ImageList do
+  # issue 202
+  describe 'images_from_imagelist' do
+    it 'works with identical instances' do
+      expect do
+        img = Magick::Image.new(1, 1)
+        list = Magick::ImageList.new
+        list << img << img
+        res = list.append(false)
+        expect(res.columns).to eq(2)
+        expect(res.rows).to eq(1)
+      end.not_to raise_error
+
+      expect do
+        img = Magick::Image.new(1, 1)
+        img2 = Magick::Image.new(3, 3)
+        list = Magick::ImageList.new
+        list.concat([img, img2, img, img2, img])
+        res = list.append(false)
+        expect(res.columns).to eq(9)
+        expect(res.rows).to eq(3)
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Fixed #202 and added tests

The cause is a loop in a linked list in `AppendImageToList`.

at rmilist.c:
```c
        t = rb_ary_entry(images, x);
        image = rm_check_destroyed(t);
        AppendImageToList(&head, image);
```

`AppendImageToList` 1st call:
- head = images[0]

`AppendImageToList` 2nd call:
- images[0]->next = images[1]
- images[1]->prev = images[0]

`AppendImageToList` 3rd call:
- images[1]->next = images[2]
- images[2]->prev = images[1]

if images[0] and images[1] are identical:
- head = images[0] = images[1]
- images[0]->next = images[1] = images[0]
- images[1]->prev = images[0] = images[1]

then it hangs because of a loop in this linked list.
